### PR TITLE
Add 3D network visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+network_edges.csv
+network_3d.html
+__pycache__/

--- a/network_3d.py
+++ b/network_3d.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+import csv
+from typing import Iterable, Tuple
+
+import networkx as nx
+import plotly.graph_objects as go
+
+
+def load_edges(path: str) -> Iterable[Tuple[str, str, float]]:
+    with open(path, newline='', encoding='utf-8') as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            try:
+                score = float(row['match_score'])
+            except (ValueError, KeyError):
+                continue
+            yield row['saudi_entity'], row['swedish_entity'], score
+
+
+def build_graph(edges: Iterable[Tuple[str, str, float]]) -> nx.Graph:
+    G = nx.Graph()
+    for sa, sw, score in edges:
+        G.add_node(sa, group='saudi')
+        G.add_node(sw, group='swedish')
+        G.add_edge(sa, sw, weight=score)
+    return G
+
+
+def plot_3d_network(G: nx.Graph, html_path: str = 'network_3d.html') -> None:
+    pos = nx.spring_layout(G, dim=3, weight='weight', seed=42)
+    edge_x, edge_y, edge_z = [], [], []
+    for u, v in G.edges():
+        x0, y0, z0 = pos[u]
+        x1, y1, z1 = pos[v]
+        edge_x.extend([x0, x1, None])
+        edge_y.extend([y0, y1, None])
+        edge_z.extend([z0, z1, None])
+    edge_trace = go.Scatter3d(x=edge_x, y=edge_y, z=edge_z,
+                              mode='lines',
+                              line=dict(width=1, color='#888'),
+                              hoverinfo='none')
+    node_x = [pos[n][0] for n in G.nodes]
+    node_y = [pos[n][1] for n in G.nodes]
+    node_z = [pos[n][2] for n in G.nodes]
+    node_text = list(G.nodes)
+    node_trace = go.Scatter3d(x=node_x, y=node_y, z=node_z,
+                              mode='markers',
+                              marker=dict(size=4, color='skyblue'),
+                              text=node_text,
+                              hoverinfo='text')
+    fig = go.Figure(data=[edge_trace, node_trace])
+    fig.update_layout(showlegend=False,
+                      margin=dict(l=0, r=0, b=0, t=0))
+    fig.write_html(html_path)
+
+
+if __name__ == '__main__':
+    graph = build_graph(load_edges('network_edges.csv'))
+    plot_3d_network(graph)

--- a/parse_results.py
+++ b/parse_results.py
@@ -1,40 +1,64 @@
-import zipfile
-from xml.etree import ElementTree as ET
+from __future__ import annotations
 import csv
+import zipfile
+from typing import List, Tuple
+from xml.etree import ElementTree as ET
 
-# parse shared strings
-with zipfile.ZipFile('SSIP Project Results.xlsx') as zf:
-    shared = ET.fromstring(zf.read('xl/sharedStrings.xml'))
-    strings = []
-    for si in shared.findall('{http://schemas.openxmlformats.org/spreadsheetml/2006/main}si'):
-        t = si.find('.//{http://schemas.openxmlformats.org/spreadsheetml/2006/main}t')
-        strings.append(t.text if t is not None else '')
 
-    sheet = ET.fromstring(zf.read('xl/worksheets/sheet2.xml'))
+NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
 
-edges = []
-for row in sheet.findall('.//{http://schemas.openxmlformats.org/spreadsheetml/2006/main}row'):
-    cells = {}
-    for c in row.findall('{http://schemas.openxmlformats.org/spreadsheetml/2006/main}c'):
-        col = ''.join(filter(str.isalpha, c.get('r')))
-        val = ''
-        if c.get('t') == 'inlineStr':
-            t = c.find('.//{http://schemas.openxmlformats.org/spreadsheetml/2006/main}t')
-            if t is not None:
-                val = t.text
-        else:
-            v = c.find('{http://schemas.openxmlformats.org/spreadsheetml/2006/main}v')
-            if v is not None:
-                val = strings[int(v.text)] if c.get('t') == 's' else v.text
-        cells[col] = val
-    sa = (cells.get('A') or '').strip().lstrip('-').lstrip('|').strip()
-    sw = (cells.get('D') or '').strip()
-    score = (cells.get('E') or '').strip()
-    if sa and sw and sa != 'problem_name':
-        edges.append((sa, sw, score))
 
-with open('network_edges.csv', 'w', newline='') as f:
-    writer = csv.writer(f)
-    writer.writerow(['saudi_entity', 'swedish_entity', 'match_score'])
-    writer.writerows(edges)
-print('wrote', len(edges), 'edges')
+def _load_shared_strings(zf: zipfile.ZipFile) -> List[str]:
+    tree = ET.fromstring(zf.read("xl/sharedStrings.xml"))
+    strings: List[str] = []
+    for si in tree.findall(f"{NS}si"):
+        t = si.find(f".//{NS}t")
+        strings.append(t.text if t is not None else "")
+    return strings
+
+
+def extract_edges(xlsx_path: str, sheet_xml: str = "xl/worksheets/sheet2.xml") -> List[Tuple[str, str, float]]:
+    """Return a list of edges from the Results worksheet."""
+    with zipfile.ZipFile(xlsx_path) as zf:
+        strings = _load_shared_strings(zf)
+        sheet = ET.fromstring(zf.read(sheet_xml))
+
+    edges: List[Tuple[str, str, float]] = []
+    for row in sheet.findall(f".//{NS}row"):
+        cells: dict[str, str] = {}
+        for c in row.findall(f"{NS}c"):
+            col = ''.join(filter(str.isalpha, c.get('r', '')))
+            val = ''
+            if c.get('t') == 'inlineStr':
+                t = c.find(f".//{NS}t")
+                if t is not None:
+                    val = t.text or ''
+            else:
+                v = c.find(f"{NS}v")
+                if v is not None:
+                    val = strings[int(v.text)] if c.get('t') == 's' else v.text or ''
+            cells[col] = (val or "").strip()
+
+        sa = cells.get('A', '').lstrip('-').lstrip('|').strip()
+        sw = cells.get('D', '').strip()
+        score_text = cells.get('E', '').strip()
+        try:
+            score = float(score_text)
+        except ValueError:
+            continue
+        if sa and sw and sa.lower() != 'problem_name':
+            edges.append((sa, sw, score))
+    return edges
+
+
+def write_edges_csv(edges: List[Tuple[str, str, float]], csv_path: str) -> None:
+    with open(csv_path, 'w', newline='', encoding='utf-8') as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["saudi_entity", "swedish_entity", "match_score"])
+        writer.writerows(edges)
+
+
+if __name__ == "__main__":
+    edges = extract_edges('SSIP Project Results.xlsx')
+    write_edges_csv(edges, 'network_edges.csv')
+    print(f"wrote {len(edges)} edges")


### PR DESCRIPTION
## Summary
- refactor `parse_results.py` into reusable functions
- add a script (`network_3d.py`) that builds a 3‑D network with NetworkX and Plotly
- ignore generated artifacts

## Testing
- `python3 parse_results.py`
- `python3 network_3d.py` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_686c191e77bc832e85d5128d435e38a1